### PR TITLE
[FIX]  fallback is checked wrong - produces a lot failed db calls

### DIFF
--- a/lib/class.tx_table_db.php
+++ b/lib/class.tx_table_db.php
@@ -1509,7 +1509,7 @@ class tx_table_db {
 			}
 		}
 
-		if (!$fallback) {
+		if ($fallback) {
 			$select_fields = $this->transformSelect($select_fields, $aliasPostfix, $collateConf);
 		}
 		$where_clause =


### PR DESCRIPTION
Hi Franz,

I'm not sure, if this was done intentionally. But semantically checking (!$fallback) is just the wrong way around, isn't it?

This produced lots of bad DB calls in my installations, which where dumped in the debug mode.

Changin it to ($fallback) seems just right though.

Greetings,
Uwe